### PR TITLE
fix index: parse callback takes 2 parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function (options) {
 
     var that = this;
     var stylestats = new StyleStats(file.contents.toString(), options.config);
-    stylestats.parse(function (result) {
+    stylestats.parse(function (error, result) {
       switch (options.type) {
         case 'json':
           var json = JSON.stringify(result, null, 2);


### PR DESCRIPTION
Callback of function `parse` takes [2 parameters](https://github.com/t32k/stylestats#stylestatsparsefn).
