### PR TITLE
Fix failure of installation with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "npm run build && mocha --timeout=3000 --reporter=spec test/test.js"
   },
   "dependencies": {
+    "6to5": "^3.3.12",
     "cli-table": "^0.3.1",
     "gulp-util": "^3.0.3",
     "json2csv": "^2.2.1",
@@ -24,7 +25,6 @@
     "underscore": "^1.7.0"
   },
   "devDependencies": {
-    "6to5": "^3.3.12",
     "mocha": "^2.1.0"
   },
   "keywords": [


### PR DESCRIPTION
I've failed to install `gulp-stylestats` with npm. The following is log messages.

```bash
$ npm install gulp-stylestats --save-dev
npm WARN deprecated json2csv@2.2.1: not maintained anymore
-
> gulp-stylestats@0.5.2 postinstall /Users/jmblog/src/kaizen-ui/node_modules/gulp-stylestats
> npm run build


> gulp-stylestats@0.5.2 build /Users/jmblog/src/kaizen-ui/node_modules/gulp-stylestats
> 6to5 src/index.js > index.js

sh: 6to5: command not found

npm ERR! gulp-stylestats@0.5.2 build: `6to5 src/index.js > index.js`
npm ERR! Exit status 127
npm ERR!
npm ERR! Failed at the gulp-stylestats@0.5.2 build script.
npm ERR! This is most likely a problem with the gulp-stylestats package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     6to5 src/index.js > index.js
```

I think `6to5` should be included in not `devDependencies` but `depenencies`.