### PR TITLE
Find stats.template file

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ var outputHTML = function (that, options, file, result, callback) {
   var _ = require("underscore");
 
   var templatePath = path.join(__dirname, "/node_modules/stylestats/assets/stats.template");
+  if (!fs.existsSync(templatePath)) {
+    templatePath = path.resolve(__dirname, "../stylestats/assets/stats.template");
+  }
   var template = _.template(fs.readFileSync(templatePath, {
     encoding: "utf8"
   }));

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,9 @@ const outputHTML = function (that, options, file, result, callback) {
   const _    = require('underscore');
 
   let templatePath = path.join(__dirname, '/node_modules/stylestats/assets/stats.template');
+  if (!fs.existsSync(templatePath)) {
+    templatePath = path.resolve(__dirname, '../stylestats/assets/stats.template');
+  }
   let template = _.template(fs.readFileSync(templatePath, {
     encoding: 'utf8'
   }));
@@ -100,7 +103,7 @@ const outputTable = function (that, options, file, result, callback) {
 module.exports = (options = {}) => {
 
   return through.obj(function (file, encode, callback) {
-    
+
     if (file.isNull()) {
       this.push(file);
       return callback();


### PR DESCRIPTION
Hi,

I have an issue that I cannot output stats to HTML file with `{type: 'html', outfile: true}` options.
If [`stylestats`](https://github.com/t32k/stylestats) is already installed before installing `gulp-stylestats`, the `stats.template` file is missing because `stylestats` is not installed inside `gulp-stylestats/node_modules/`. This seems the reason for my issue.