### PR TITLE
Fix installation failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "test": "npm run build && mocha --timeout=3000 --reporter=spec test/test.js"
   },
   "dependencies": {
+    "babel": "^4.5.1",
     "gulp-util": "^3.0.4",
     "stylestats": "^5.0.0",
     "through2": "^0.6.3"
   },
   "devDependencies": {
-    "babel": "^4.5.1",
     "mocha": "^2.1.0"
   },
   "keywords": [


### PR DESCRIPTION
Couldn't do an `npm install gulp-stylestats` successfully.
```
> gulp-stylestats@0.5.4 postinstall d:\_projects\temp-stylestats\node_modules\gulp-stylestats
> npm run build


> gulp-stylestats@0.5.4 build d:\_projects\temp-stylestats\node_modules\gulp-stylestats
> babel src/index.js > index.js

'babel' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! weird error 1
npm ERR! not ok code 0
npm ERR! weird error 1
npm ERR! not ok code 0
```

Bug looks to be caused by this commit:
https://github.com/1000ch/gulp-stylestats/commit/78457b184b16be725b924a8d9a867221ab6088c4#diff-1

It appears that this is the same problem solved by https://github.com/1000ch/gulp-stylestats/pull/9 and thus the fix is moving `babel` from "devDependencies" to "dependencies" in `package.json`.
