### PR TITLE
use file.path instead of file.content to add the pathname to the output

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,8 @@ module.exports = function () {
       return callback();
     }
 
-    var contents = file.contents.toString();
     var config = options.config;
-    var stylestats = new StyleStats(contents, config);
+    var stylestats = new StyleStats(file.path, config);
 
     stylestats.parse(function (error, result) {
 


### PR DESCRIPTION
fix for this issue: https://github.com/1000ch/gulp-stylestats/issues/11