### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const gutil = require('gulp-util');
+const PluginError = require('plugin-error');
+const replaceExt = require('replace-ext');
 const through = require('through2');
 const StyleStats = require('stylestats');
 const Format = require('stylestats/lib/format');
@@ -12,7 +13,7 @@ module.exports = (options = {}) => through.obj(function (file, encode, callback)
   }
 
   if (file.isStream()) {
-    this.emit('error', new gutil.PluginError('gulp-stylestats', 'Streaming is not supported'));
+    this.emit('error', new PluginError('gulp-stylestats', 'Streaming is not supported'));
     return callback();
   }
 
@@ -41,7 +42,7 @@ module.exports = (options = {}) => through.obj(function (file, encode, callback)
     Promise.resolve(format[method]()).then(data => {
       if (options.outfile) {
         file.contents = new Buffer(data);
-        file.path = gutil.replaceExtension(file.path, extension);
+        file.path = replaceExt(file.path, extension);
       } else {
         console.log(data);
       }
@@ -51,7 +52,7 @@ module.exports = (options = {}) => through.obj(function (file, encode, callback)
     });
   }).catch(err => {
     this.push(file);
-    callback(new gutil.PluginError('gulp-stylestats', err, {
+    callback(new PluginError('gulp-stylestats', err, {
       fileName: file.path
     }));
   });

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "gulp-util": "^3.0.7",
+    "plugin-error": "^1.0.1",
+    "replace-ext": "^1.0.0",
     "stylestats": "^7.0.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {
     "ava": "^0.18.1",
+    "vinyl": "^2.1.0",
     "xo": "^0.17.1"
   },
   "xo": {

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const test = require('ava');
-const gutil = require('gulp-util');
+const Vinyl = require('vinyl');
 const stylestats = require('../');
 
 test.cb('should log css statistics', t => {
@@ -20,7 +20,7 @@ test.cb('should log css statistics', t => {
     t.end();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp,
     contents: fs.readFileSync(fp)
   }));
@@ -46,7 +46,7 @@ test.cb('should create css statistics', t => {
     t.end();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp,
     contents: fs.readFileSync(fp)
   }));
@@ -105,7 +105,7 @@ test.cb('should create css statistics with config', t => {
     t.end();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp,
     contents: fs.readFileSync(fp)
   }));
@@ -128,12 +128,12 @@ test.cb('should log multiple css statistics', t => {
     t.end();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp1,
     contents: fs.readFileSync(fp1)
   }));
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp2,
     contents: fs.readFileSync(fp2)
   }));
@@ -157,7 +157,7 @@ test.cb('should log css statistics as JSON', t => {
     t.end();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp,
     contents: fs.readFileSync(fp)
   }));
@@ -184,7 +184,7 @@ test.cb('should create css statistics as JSON', t => {
     t.end();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp,
     contents: fs.readFileSync(fp)
   }));
@@ -208,7 +208,7 @@ test.cb('should log css statistics as CSV', t => {
     t.end();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp,
     contents: fs.readFileSync(fp)
   }));
@@ -235,7 +235,7 @@ test.cb('should create css statistics as CSV', t => {
     t.end();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new Vinyl({
     path: fp,
     contents: fs.readFileSync(fp)
   }));

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const test = require('ava');
 const gutil = require('gulp-util');
 const stylestats = require('../');
@@ -32,8 +33,8 @@ test.cb('should create css statistics', t => {
   let stream = stylestats({
     outfile: true
   });
-  let fp = `${__dirname}/fixtures/test.css`;
-  let dest = `${__dirname}/fixtures/test.txt`;
+  let fp = path.join(__dirname, '/fixtures/test.css');
+  let dest = path.join(__dirname, '/fixtures/test.txt');
 
   stream.on('data', file => {
     count++;
@@ -91,8 +92,8 @@ test.cb('should create css statistics with config', t => {
     floatProperties: false,
     mediaQueries: false
   });
-  let fp = `${__dirname}/fixtures/test.css`;
-  let dest = `${__dirname}/fixtures/test.txt`;
+  let fp = path.join(__dirname, '/fixtures/test.css');
+  let dest = path.join(__dirname, '/fixtures/test.txt');
 
   stream.on('data', file => {
     count++;
@@ -115,8 +116,8 @@ test.cb('should create css statistics with config', t => {
 test.cb('should log multiple css statistics', t => {
   let count = 0;
   let stream = stylestats();
-  let fp1 = `${__dirname}/fixtures/test.css`;
-  let fp2 = `${__dirname}/fixtures/kite.css`;
+  let fp1 = path.join(__dirname, '/fixtures/test.css');
+  let fp2 = path.join(__dirname, '/fixtures/kite.css');
 
   stream.on('data', () => {
     count++;
@@ -145,7 +146,7 @@ test.cb('should log css statistics as JSON', t => {
   let stream = stylestats({
     type: 'json'
   });
-  let fp = `${__dirname}/fixtures/test.css`;
+  let fp = path.join(__dirname, '/fixtures/test.css');
 
   stream.on('data', () => {
     count++;
@@ -170,8 +171,8 @@ test.cb('should create css statistics as JSON', t => {
     type: 'json',
     outfile: true
   });
-  let fp = `${__dirname}/fixtures/test.css`;
-  let dest = `${__dirname}/fixtures/test.json`;
+  let fp = path.join(__dirname, '/fixtures/test.css');
+  let dest = path.join(__dirname, '/fixtures/test.json');
 
   stream.on('data', file => {
     count++;
@@ -196,7 +197,7 @@ test.cb('should log css statistics as CSV', t => {
   let stream = stylestats({
     type: 'csv'
   });
-  let fp = `${__dirname}/fixtures/test.css`;
+  let fp = path.join(__dirname, '/fixtures/test.css');
 
   stream.on('data', () => {
     count++;
@@ -221,8 +222,8 @@ test.cb('should create css statistics as CSV', t => {
     type: 'csv',
     outfile: true
   });
-  let fp = `${__dirname}/fixtures/test.css`;
-  let dest = `${__dirname}/fixtures/test.csv`;
+  let fp = path.join(__dirname, '/fixtures/test.css');
+  let dest = path.join(__dirname, '/fixtures/test.csv');
 
   stream.on('data', file => {
     count++;


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp.

The [README.md](https://github.com/gulpjs/gulp-util) lists alternatives for all the components so a simple replacement should be enough.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143